### PR TITLE
avoid istio-proxy containers logs being parsed as logformat

### DIFF
--- a/conf.d/logfmt.conf
+++ b/conf.d/logfmt.conf
@@ -1,6 +1,11 @@
 <match kubernetes.**>
   @type rewrite_tag_filter
   <rule>
+    key     $.kubernetes.container_name
+    pattern /^istio-proxy$/
+    tag     istio.${tag}
+  </rule>
+  <rule>
     key     $.kubernetes.labels.logformat
     pattern /^logfmt$/
     tag     logfmt.${tag}


### PR DESCRIPTION
## what
*  avoid istio-proxy containers logs being parsed as logformat

## why
* istio-proxy containers is injected by istio. It shares labes with pod, so if pod have a `logformat=logfmt`, then istio-proxy logs will be parsed as `logfmt` which is bad.