### PR TITLE
throttle added, logfmt disabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM cloudposse/fluentd-kubernetes-daemonset:v1.4.2-debian-elasticsearch-1.0
 
 RUN gem install fluent-plugin-parser-logfmt \
  && gem install fluent-plugin-rewrite-tag-filter \
+ && gem install fluent-plugin-throttle \
  && gem sources --clear-all \
  && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem
 

--- a/conf.d/logfmt.conf
+++ b/conf.d/logfmt.conf
@@ -1,25 +1,35 @@
-<match kubernetes.**>
-  @type rewrite_tag_filter
-  <rule>
-    key     $.kubernetes.container_name
-    pattern /^istio-proxy$/
-    tag     istio.${tag}
-  </rule>
-  <rule>
-    key     $.kubernetes.labels.logformat
-    pattern /^logfmt$/
-    tag     logfmt.${tag}
-  </rule>
-  <rule>
-    key     log
-    pattern /.+/
-    tag     system.${tag}
-  </rule>
-</match>
 
-<filter logfmt.**>
-  @type parser
-  key_name log
-  format logfmt
-  reserve_data true
-</filter>
+## disabling logfmt parsing, because any attempt to parse log that are not in
+## logfmt format cause the corruption of ES indices by introducing many
+## meaningless index fields.
+## In case of index reach the fields limit (1000 by default) fluentd will get
+## ElasticsearchError error="400 - Rejected by Elasticsearch" error
+##
+## To enable it back we have to make sure that fluent-plugin-parser-logfmt will
+## not emit record with `badly` parsed logs
+
+# <match kubernetes.**>
+#   @type rewrite_tag_filter
+#   <rule>
+#     key     $.kubernetes.container_name
+#     pattern /^istio-proxy$/
+#     tag     istio.${tag}
+#   </rule>
+#   <rule>
+#     key     $.kubernetes.labels.logformat
+#     pattern /^logfmt$/
+#     tag     logfmt.${tag}
+#   </rule>
+#   <rule>
+#     key     log
+#     pattern /.+/
+#     tag     system.${tag}
+#   </rule>
+# </match>
+# 
+# <filter logfmt.**>
+#   @type parser
+#   key_name log
+#   format logfmt
+#   reserve_data true
+# </filter>

--- a/conf.d/throttle.conf
+++ b/conf.d/throttle.conf
@@ -1,0 +1,12 @@
+## see documentation here:
+## https://github.com/rubrikinc/fluent-plugin-throttle
+
+## drop logs after reaching 20k records in 10 minutes
+## group_reset_rate_s is default to 20000/600 = 33.33... log/s
+<filter **>
+  @type throttle
+  group_key kubernetes.pod_name
+  group_bucket_period_s  600
+  group_bucket_limit   20000
+  group_drop_logs       true
+</filter>


### PR DESCRIPTION
## what
* log throttle added
* logfmt disabled

## why
* to avoid spamming ElasticSearch 
* because any attempt to parse log that are not in logfmt format cause the corruption of ES indices by introducing many meaningless index fields. In case of index reach the fields limit (1000 by default) fluentd will get ElasticsearchError error="400 - Rejected by Elasticsearch" error
