### PR TITLE
Activated throttling generate prometheus metrics

### DIFF
--- a/conf.d/throttle.conf
+++ b/conf.d/throttle.conf
@@ -37,7 +37,6 @@
     key rate_s
     <labels>
       group_key ${group_key}
-      rate_limit_s ${rate_limit_s}
     </labels>
   </metric>
   @type prometheus
@@ -47,7 +46,6 @@
     desc Number of messages being throttled counter
         <labels>
         group_key ${group_key}
-        rate_limit_s ${rate_limit_s}
         </labels>
   </metric>
   </filter>

--- a/conf.d/throttle.conf
+++ b/conf.d/throttle.conf
@@ -19,3 +19,40 @@
   group_reset_rate_s    "#{ENV['FLUENTD_THROTTLE_GROUP_RESET_RATE']}"
   group_warning_delay_s "#{ENV['FLUENTD_THROTTLE_GROUP_WARNING_DELAY']}"
 </filter>
+
+<label @FLUENT_LOG>
+  <filter fluent.warn>
+    @type grep
+  <regexp>
+    key message
+    pattern /rate exceeded/
+  </regexp>
+  </filter>
+  <filter fluent.warn>
+  @type prometheus
+  <metric>
+    name fluentd_events_rate_exceeded
+    type gauge
+    desc Number of messages being throttled per second
+    key rate_s
+    <labels>
+      group_key ${group_key}
+      rate_limit_s ${rate_limit_s}
+    </labels>
+  </metric>
+  @type prometheus
+  <metric>
+    name fluentd_events_rate_exceeded_messages_total
+    type counter
+    desc Number of messages being throttled counter
+        <labels>
+        group_key ${group_key}
+        rate_limit_s ${rate_limit_s}
+        </labels>
+  </metric>
+  </filter>
+
+  <match fluent.warn>
+    @type stdout
+  </match>
+</label>

--- a/conf.d/throttle.conf
+++ b/conf.d/throttle.conf
@@ -36,7 +36,7 @@
     desc Number of messages being throttled per second
     key rate_s
     <labels>
-      group_key ${group_key}
+      group_key ${group_key[0]}
     </labels>
   </metric>
   @type prometheus
@@ -44,9 +44,9 @@
     name fluentd_events_rate_exceeded_messages_total
     type counter
     desc Number of messages being throttled counter
-        <labels>
-        group_key ${group_key}
-        </labels>
+    <labels>
+      group_key ${group_key[0]}
+    </labels>
   </metric>
   </filter>
 


### PR DESCRIPTION
# what
- added `fluentd_events_rate_exceeded` and `fluentd_events_rate_exceeded_messages_total`

# why
- to enable monitoring fluentd throttling with prometheus
`increase(fluentd_events_rate_exceeded_messages_total[15m]) > 0` will trigger an alert when there is log increase and throttling is  activated
Additional gauge `fluentd_events_rate_exceeded` can be used to debug rate of throttled messages