### PR TITLE
logfmt plugin removed from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM cloudposse/fluentd-kubernetes-daemonset:v1.4.2-debian-elasticsearch-1.0
 
-RUN gem install fluent-plugin-parser-logfmt \
- && gem install fluent-plugin-rewrite-tag-filter \
+RUN gem install fluent-plugin-rewrite-tag-filter \
  && gem install fluent-plugin-throttle \
  && gem sources --clear-all \
  && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem


### PR DESCRIPTION
## what
* logfmt plugin removed from image

## why
* not rules left to use logfmt any more