### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -1,3 +1,4 @@
+
 # Name of this project
 name: fluentd-kubernetes-logformat
 


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143